### PR TITLE
Upgraded typing_extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 # resolve issue with tf==2.4 and gradio dependency collision issue
-RUN pip install --force-reinstall typing_extensions==4.4.0
+RUN pip install --force-reinstall typing_extensions==4.7.1
 
 # Install wget
 RUN apt install wget -y && \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ license: mit
 app_file: app.py
 ---
 
-<div align="center">M
+<div align="center">
 <h1 align="center">neukit</h1>
 <h3 align="center">Automatic brain extraction and preoperative tumor segmentation from MRI</h3>
 
@@ -22,7 +22,7 @@ app_file: app.py
 
 </div>
 
-## Intro
+## Brief intro
 
 This web application enables users to test [Raidionics](https://raidionics.github.io/), which is an open-source, free-to-use desktop application for pre- and postoperative central nervous system tumor segmentation and standardized reporting. The app only supports single volume input and only demonstrates the segmentation results of the Raidionics software, and thus is only meant for demonstration purposes.
 


### PR DESCRIPTION
This is due to `typing_extensions==4.4.0` being broken with `gradio`/`fastapi`, even for fixed versioning...
See: https://github.com/tiangolo/fastapi/discussions/9808